### PR TITLE
Fix: Area code prefix "1-"

### DIFF
--- a/PhoneFix.py
+++ b/PhoneFix.py
@@ -9,6 +9,7 @@ def main():
     #Remove obnoxious North American area code
     #Maybe should look into making the area code removable regardless of location
     entry = phone.removeprefix("+1").strip()
+    entry = entry.removeprefix("1-").strip()
 
     #Check if input was only digits and format
     if entry.isalnum():


### PR DESCRIPTION
Fixed an unformatted instance for area codes when they are only separated by a hyphen

Example: 1-234-567-8912